### PR TITLE
add gci linter and fix import ordering

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - depguard
     - errcheck
     - errorlint
+    - gci
     - goconst
     - gocritic
     - gofmt
@@ -112,3 +113,14 @@ linters-settings:
             desc: io/ioutil is deprecated. Use package io or os instead.
           - pkg: "github.com/stretchr/testify/assert"
             desc: github.com/stretchr/testify/require should be used instead.
+  gci:
+    sections:
+      - standard
+      - default
+      - blank
+      - prefix(github.com/ava-labs/avalanche-tooling-sdk-go)
+      - alias
+      - dot
+    custom-order: true
+  gofumpt:
+    extra-rules: false

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -13,6 +13,16 @@ import (
 	"os"
 	"time"
 
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/subnet-evm/commontype"
+	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
+	"go.uber.org/zap"
+
 	"github.com/ava-labs/avalanche-tooling-sdk-go/evm"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/interchain"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/multisig"
@@ -21,17 +31,8 @@ import (
 	"github.com/ava-labs/avalanche-tooling-sdk-go/validatormanager"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/vm"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/wallet"
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	commonAvago "github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
-	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/libevm/core"
-	"github.com/ava-labs/subnet-evm/commontype"
-	"github.com/ava-labs/subnet-evm/params"
-	"github.com/ava-labs/subnet-evm/params/extras"
 
-	"go.uber.org/zap"
+	commonAvago "github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
 )
 
 var (

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -10,10 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/keychain"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/vm"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/wallet"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
@@ -21,8 +17,12 @@ import (
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/utils"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/keychain"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/vm"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/wallet"
 )
 
 func getDefaultSubnetEVMGenesis() SubnetParams {

--- a/blockchain/deploy_subnet.go
+++ b/blockchain/deploy_subnet.go
@@ -6,13 +6,14 @@ package blockchain
 import (
 	"fmt"
 
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
 	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/multisig"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/wallet"
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
 // CreateSubnetTx creates uncommitted CreateSubnetTx

--- a/blockchain/helper.go
+++ b/blockchain/helper.go
@@ -4,12 +4,11 @@
 package blockchain
 
 import (
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 
 	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
-
-	"github.com/ava-labs/avalanchego/ids"
 )
 
 func GetSubnet(subnetID ids.ID, network network.Network) (platformvm.GetSubnetClientResponse, error) {

--- a/evm/contract/contract.go
+++ b/evm/contract/contract.go
@@ -3,7 +3,6 @@
 package contract
 
 import (
-	_ "embed"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -11,15 +10,16 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/evm"
-	sdkUtils "github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/evm"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 )
 
 var ErrFailedReceiptStatus = fmt.Errorf("failed receipt status")
@@ -252,7 +252,7 @@ func ParseSpec(
 	}
 	if event {
 		for i := range inputsMaps {
-			if sdkUtils.Belongs(indexedFields, i) {
+			if utils.Belongs(indexedFields, i) {
 				inputsMaps[i]["indexed"] = true
 			} else {
 				inputsMaps[i]["indexed"] = false
@@ -407,7 +407,7 @@ func TxToMethodWithWarpMessage(
 	from common.Address,
 	privateKey string,
 	contractAddress common.Address,
-	warpMessage *avalancheWarp.Message,
+	warpMessage *warp.Message,
 	payment *big.Int,
 	description string,
 	errorSignatureToError map[string]error,

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -12,20 +12,22 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
-	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
-	ethereum "github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/crypto"
-	ethparams "github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
 	"github.com/ava-labs/subnet-evm/ethclient"
 	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/plugin/evm/upgrade/legacy"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/warp"
 	"github.com/ava-labs/subnet-evm/predicate"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
+
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	ethereum "github.com/ava-labs/libevm"
+	ethparams "github.com/ava-labs/libevm/params"
 	subnetEvmUtils "github.com/ava-labs/subnet-evm/utils"
 )
 

--- a/evm/evm_test.go
+++ b/evm/evm_test.go
@@ -11,17 +11,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
-	mockethclient "github.com/ava-labs/avalanche-tooling-sdk-go/mocks/ethclient"
-	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
-	ethereum "github.com/ava-labs/libevm"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/crypto"
-	subnetethclient "github.com/ava-labs/subnet-evm/ethclient"
-
+	"github.com/ava-labs/subnet-evm/ethclient"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
+
+	mockethclient "github.com/ava-labs/avalanche-tooling-sdk-go/mocks/ethclient"
+	ethereum "github.com/ava-labs/libevm"
 )
 
 func TestHasScheme(t *testing.T) {
@@ -101,7 +102,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 	tests := []struct {
 		name           string
 		rpcURL         string
-		mockDialFunc   func(context.Context, string) (subnetethclient.Client, error)
+		mockDialFunc   func(context.Context, string) (ethclient.Client, error)
 		expectedScheme string
 		expectError    bool
 	}{
@@ -113,7 +114,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 		{
 			name:   "success with ws scheme",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, url string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, url string) (ethclient.Client, error) {
 				if strings.HasPrefix(url, "ws://") {
 					return mockethclient.NewMockClient(gomock.NewController(t)), nil
 				}
@@ -125,7 +126,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 		{
 			name:   "failure with ws scheme",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, url string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, url string) (ethclient.Client, error) {
 				if strings.HasPrefix(url, "ws://") {
 					return nil, errors.New("unexpected error on ws connection")
 				}
@@ -136,7 +137,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 		{
 			name:   "success with wss scheme",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, url string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, url string) (ethclient.Client, error) {
 				if strings.HasPrefix(url, "ws://") {
 					return nil, errors.New("websocket: bad handshake")
 				}
@@ -151,7 +152,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 		{
 			name:   "failure with wss scheme",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, url string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, url string) (ethclient.Client, error) {
 				if strings.HasPrefix(url, "ws://") {
 					return nil, errors.New("websocket: bad handshake")
 				}
@@ -165,7 +166,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 		{
 			name:   "success with https scheme",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, url string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, url string) (ethclient.Client, error) {
 				if strings.HasPrefix(url, "ws://") {
 					return nil, errors.New("websocket: bad handshake")
 				}
@@ -185,7 +186,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 		{
 			name:   "failure with https scheme",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, url string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, url string) (ethclient.Client, error) {
 				if strings.HasPrefix(url, "ws://") {
 					return nil, errors.New("websocket: bad handshake")
 				}
@@ -204,7 +205,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 		{
 			name:   "success with http scheme",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, url string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, url string) (ethclient.Client, error) {
 				if strings.HasPrefix(url, "ws://") {
 					return nil, errors.New("websocket: bad handshake")
 				}
@@ -227,7 +228,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 		{
 			name:   "error - url with scheme",
 			rpcURL: "http://localhost:8545",
-			mockDialFunc: func(_ context.Context, _ string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, _ string) (ethclient.Client, error) {
 				return nil, nil
 			},
 			expectError: true,
@@ -235,7 +236,7 @@ func TestGetClientWithoutScheme(t *testing.T) {
 		{
 			name:   "error - unknown protocol",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, _ string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, _ string) (ethclient.Client, error) {
 				return nil, errors.New("unknown protocol")
 			},
 			expectError: true,
@@ -274,7 +275,7 @@ func TestGetClient(t *testing.T) {
 	tests := []struct {
 		name         string
 		rpcURL       string
-		mockDialFunc func(context.Context, string) (subnetethclient.Client, error)
+		mockDialFunc func(context.Context, string) (ethclient.Client, error)
 		expectError  bool
 	}{
 		{
@@ -285,7 +286,7 @@ func TestGetClient(t *testing.T) {
 		{
 			name:   "with scheme, total failure",
 			rpcURL: "http://localhost:8545",
-			mockDialFunc: func(_ context.Context, _ string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, _ string) (ethclient.Client, error) {
 				failuresCount++
 				if failuresCount <= repeatsOnFailure {
 					return nil, errors.New("connection error")
@@ -297,7 +298,7 @@ func TestGetClient(t *testing.T) {
 		{
 			name:   "with scheme, 2 failures",
 			rpcURL: "http://localhost:8545",
-			mockDialFunc: func(_ context.Context, _ string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, _ string) (ethclient.Client, error) {
 				failuresCount++
 				if failuresCount < repeatsOnFailure {
 					return nil, errors.New("connection error")
@@ -309,7 +310,7 @@ func TestGetClient(t *testing.T) {
 		{
 			name:   "with scheme",
 			rpcURL: "http://localhost:8545",
-			mockDialFunc: func(_ context.Context, _ string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, _ string) (ethclient.Client, error) {
 				return mockethclient.NewMockClient(ctrl), nil
 			},
 			expectError: false,
@@ -317,7 +318,7 @@ func TestGetClient(t *testing.T) {
 		{
 			name:   "without scheme",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, url string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, url string) (ethclient.Client, error) {
 				if strings.HasPrefix(url, "ws://") {
 					return nil, errors.New("websocket: bad handshake")
 				}
@@ -1803,18 +1804,18 @@ func TestTransactWithWarpMessage(t *testing.T) {
 	contractAddress := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	callData := []byte{1, 2, 3, 4, 5}
 	value := big.NewInt(1000000000000000000) // 1 ETH
-	unsignedMessage := avalancheWarp.UnsignedMessage{
+	unsignedMessage := warp.UnsignedMessage{
 		SourceChainID: [32]byte{1, 2, 3},
 		Payload:       []byte{4, 5, 6},
 	}
-	warpMessage := &avalancheWarp.Message{
+	warpMessage := &warp.Message{
 		UnsignedMessage: unsignedMessage,
 	}
 	tests := []struct {
 		name              string
 		from              common.Address
 		privateKey        string
-		warpMessage       *avalancheWarp.Message
+		warpMessage       *warp.Message
 		contract          common.Address
 		callData          []byte
 		value             *big.Int

--- a/evm/precompiles/allowlist.go
+++ b/evm/precompiles/allowlist.go
@@ -3,12 +3,12 @@
 package precompiles
 
 import (
-	_ "embed"
 	"math/big"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
 )
 
 func SetAdmin(

--- a/evm/precompiles/precompiles.go
+++ b/evm/precompiles/precompiles.go
@@ -3,8 +3,6 @@
 package precompiles
 
 import (
-	_ "embed"
-
 	"github.com/ava-labs/subnet-evm/precompile/contracts/nativeminter"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/warp"
 )

--- a/evm/precompiles/warp.go
+++ b/evm/precompiles/warp.go
@@ -3,10 +3,9 @@
 package precompiles
 
 import (
-	_ "embed"
+	"github.com/ava-labs/avalanchego/ids"
 
 	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
-	"github.com/ava-labs/avalanchego/ids"
 )
 
 func WarpPrecompileGetBlockchainID(

--- a/evm/trace.go
+++ b/evm/trace.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/subnet-evm/rpc"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 )
 
 var ErrUnknownErrorSelector = fmt.Errorf("unknown error selector")

--- a/evm/trace_test.go
+++ b/evm/trace_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	subnetethclient "github.com/ava-labs/subnet-evm/ethclient"
+	"github.com/ava-labs/subnet-evm/ethclient"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +35,7 @@ func TestGetRawClient(t *testing.T) {
 		name            string
 		rpcURL          string
 		mockRPCDialFunc func(context.Context, string) (*rpc.Client, error)
-		mockDialFunc    func(context.Context, string) (subnetethclient.Client, error)
+		mockDialFunc    func(context.Context, string) (ethclient.Client, error)
 		expectError     bool
 	}{
 		{
@@ -78,7 +78,7 @@ func TestGetRawClient(t *testing.T) {
 		{
 			name:   "without scheme, can't get scheme",
 			rpcURL: "localhost:8545",
-			mockDialFunc: func(_ context.Context, _ string) (subnetethclient.Client, error) {
+			mockDialFunc: func(_ context.Context, _ string) (ethclient.Client, error) {
 				return nil, errors.New("invalid")
 			},
 			expectError: true,

--- a/evm/warp.go
+++ b/evm/warp.go
@@ -5,8 +5,9 @@ package evm
 import (
 	"fmt"
 
-	warp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/libevm/core/types"
+
 	subnetEvmWarp "github.com/ava-labs/subnet-evm/precompile/contracts/warp"
 )
 

--- a/evm/warp_test.go
+++ b/evm/warp_test.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
-	"github.com/ava-labs/libevm/core/types"
-	subnetevmwarp "github.com/ava-labs/subnet-evm/precompile/contracts/warp"
-
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
 	"github.com/stretchr/testify/require"
+
+	subnetevmwarp "github.com/ava-labs/subnet-evm/precompile/contracts/warp"
 )
 
 func TestGetWarpMessagesFromLogs(t *testing.T) {

--- a/interchain/signature-aggregator.go
+++ b/interchain/signature-aggregator.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
-	signatureAggregator "github.com/ava-labs/icm-services/signature-aggregator/api"
+	"github.com/ava-labs/icm-services/signature-aggregator/api"
 	"go.uber.org/zap"
 )
 
@@ -39,7 +39,7 @@ func SignMessage(
 	} else if quorumPercentage > 100 {
 		return nil, fmt.Errorf("quorum percentage cannot be greater than 100")
 	}
-	request := signatureAggregator.AggregateSignatureRequest{
+	request := api.AggregateSignatureRequest{
 		Message:          message,
 		SigningSubnetID:  signingSubnetID,
 		QuorumPercentage: quorumPercentage,
@@ -118,7 +118,7 @@ func SignMessage(
 			continue
 		}
 
-		var response signatureAggregator.AggregateSignatureResponse
+		var response api.AggregateSignatureResponse
 		if err := json.Unmarshal(body, &response); err != nil {
 			lastErr = fmt.Errorf("failed to parse response: %w", err)
 			logger.Error("Error parsing response",

--- a/key/soft_key.go
+++ b/key/soft_key.go
@@ -12,8 +12,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/cb58"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
@@ -22,8 +20,10 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/libevm/crypto"
-
 	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 )
 
 var (

--- a/keychain/keychain.go
+++ b/keychain/keychain.go
@@ -5,12 +5,13 @@ package keychain
 import (
 	"fmt"
 
+	"github.com/ava-labs/avalanchego/utils/crypto/keychain"
+	"golang.org/x/exp/maps"
+
 	"github.com/ava-labs/avalanche-tooling-sdk-go/key"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/ledger"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
 	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
-	"github.com/ava-labs/avalanchego/utils/crypto/keychain"
-	"golang.org/x/exp/maps"
 )
 
 type Keychain struct {

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -5,12 +5,13 @@ package ledger
 import (
 	"fmt"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 	"github.com/ava-labs/avalanchego/utils/crypto/keychain"
 	"github.com/ava-labs/avalanchego/utils/crypto/ledger"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 )
 
 const (

--- a/multisig/multisig.go
+++ b/multisig/multisig.go
@@ -6,14 +6,15 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 )
 
 type TxKind int64

--- a/publicarchive/downloader.go
+++ b/publicarchive/downloader.go
@@ -14,12 +14,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
-	avagoConstants "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/cavaliergopher/grab/v3"
 	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
+
+	avagoConstants "github.com/ava-labs/avalanchego/utils/constants"
 )
 
 const (

--- a/publicarchive/downloader_test.go
+++ b/publicarchive/downloader_test.go
@@ -14,12 +14,12 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
-
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
 )
 
 func TestNewGetter(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/constants"
 )
 
 func TestUnique(t *testing.T) {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -5,12 +5,14 @@ package validator
 import (
 	"encoding/json"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
 	"github.com/ava-labs/avalanchego/ids"
-	avalanchegojson "github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/rpc"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/utils"
+
+	avalanchegojson "github.com/ava-labs/avalanchego/utils/json"
 )
 
 type ValidatorKind int64

--- a/validatormanager/root.go
+++ b/validatormanager/root.go
@@ -7,18 +7,20 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/validatormanager/validatormanagertypes"
 	"github.com/ava-labs/avalanchego/ids"
-	avagoconstants "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
-	warpMessage "github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
-	warpPayload "github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/validatormanager/validatormanagertypes"
+
+	avagoconstants "github.com/ava-labs/avalanchego/utils/constants"
+	warpMessage "github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
+	warpPayload "github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
 )
 
 type ACP99ValidatorManagerSettings struct {

--- a/validatormanager/validator_manager.go
+++ b/validatormanager/validator_manager.go
@@ -6,12 +6,13 @@ package validatormanager
 import (
 	"fmt"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/validator"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/subnet-evm/accounts/abi"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/network"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/validator"
 )
 
 type GetValidatorReturn struct {

--- a/validatormanager/validator_manager_poa.go
+++ b/validatormanager/validator_manager_poa.go
@@ -4,11 +4,12 @@
 package validatormanager
 
 import (
-	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
 )
 
 // PoAValidatorManagerInitialize initializes contract [managerAddress] at [rpcURL], to

--- a/validatormanager/validator_manager_pos.go
+++ b/validatormanager/validator_manager_pos.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/evm"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
-	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/precompiles"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/evm"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/contract"
+	"github.com/ava-labs/avalanche-tooling-sdk-go/evm/precompiles"
 )
 
 // initializes contract [managerAddress] at [rpcURL], to

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5,13 +5,15 @@ package wallet
 import (
 	"context"
 
-	"github.com/ava-labs/avalanche-tooling-sdk-go/keychain"
 	"github.com/ava-labs/avalanchego/ids"
-	avagokeychain "github.com/ava-labs/avalanchego/utils/crypto/keychain"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
 	"github.com/ava-labs/avalanchego/wallet/subnet/primary/common"
+
+	"github.com/ava-labs/avalanche-tooling-sdk-go/keychain"
+
+	avagokeychain "github.com/ava-labs/avalanchego/utils/crypto/keychain"
 )
 
 type Wallet struct {


### PR DESCRIPTION
Add gci (goimports with custom import grouping) to golangci-lint configuration and fix import ordering across all Go files to comply with the new linter rules.